### PR TITLE
Add wildcard support in deck edit

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -884,9 +884,12 @@ bool DeckBuilder::CardNameCompare(const wchar_t *sa, const wchar_t *sb)
 {
 	int i = 0;
 	int j = 0;
+	int k;
 	wchar_t ca;
 	wchar_t cb;
 	wchar_t wc = L'*';
+	wchar_t pwc;
+	bool wcr = false;
 
 	if (!sa || !sb)
 		return false;
@@ -908,11 +911,19 @@ bool DeckBuilder::CardNameCompare(const wchar_t *sa, const wchar_t *sb)
 				if (!sb[j])
 					return true;
 			}
-			while (sa[i] != sb[j]) {
+			k = j;
+			pwc = towupper(sb[j]);
+			wcr = true;
+			while (towupper(sa[i]) != pwc) {
 				i++;
 				if (!sa[i])
 					return false;
 			}
+			i--;
+		}
+		else if (wcr && ca == pwc)
+		{
+			j = k;
 			i--;
 		}
 		else

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -886,6 +886,7 @@ bool DeckBuilder::CardNameCompare(const wchar_t *sa, const wchar_t *sb)
 	int j = 0;
 	wchar_t ca;
 	wchar_t cb;
+	wchar_t wc = btowc((int)'*');
 
 	if (!sa || !sb)
 		return false;
@@ -898,6 +899,21 @@ bool DeckBuilder::CardNameCompare(const wchar_t *sa, const wchar_t *sb)
 			j++;
 			if (!sb[j])
 				return true;
+		}
+		else if (cb == wc)
+		{
+			while (sb[j] == wc)
+			{
+				j++;
+				if (!sb[j])
+					return true;
+			}
+			while (sa[i] != sb[j]) {
+				i++;
+				if (!sa[i])
+					return false;
+			}
+			i--;
 		}
 		else
 			j = 0;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -886,7 +886,7 @@ bool DeckBuilder::CardNameCompare(const wchar_t *sa, const wchar_t *sb)
 	int j = 0;
 	wchar_t ca;
 	wchar_t cb;
-	wchar_t wc = btowc((int)'*');
+	wchar_t wc = L'*';
 
 	if (!sa || !sb)
 		return false;


### PR DESCRIPTION
If a search term contains `*`, the game will return results for which any text is in place of `*`.