### PR TITLE
Fix compilation issues with nlohmann-json on GCC/POSIX

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1,3 +1,12 @@
+#include <sstream>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+#ifndef _WIN32
+#include <sys/types.h>
+#include <dirent.h>
+#endif
+
 #include "config.h"
 #include "game.h"
 #include "sound_manager.h"
@@ -11,14 +20,6 @@
 #include "single_mode.h"
 #ifdef _WIN32
 #include "../irrlicht/src/CIrrDeviceWin32.h"
-#endif
-#include <sstream>
-#include <fstream>
-#include <nlohmann/json.hpp>
-
-#ifndef _WIN32
-#include <sys/types.h>
-#include <dirent.h>
 #endif
 
 unsigned short PRO_VERSION = 0x1348;


### PR DESCRIPTION
Other typedefs with the same name as the ones used by the library are taken as reference when templating. Will submit PR to nlohmann/json as well