### PR TITLE
[macOS] Include <cmath> for std::floor in "CGUICustomText.cpp"

### DIFF
--- a/gframe/CGUICustomText/CGUICustomText.cpp
+++ b/gframe/CGUICustomText/CGUICustomText.cpp
@@ -8,6 +8,7 @@
 #include "rect.h"
 #include "../IrrlichtCommonIncludes/os.h"
 #include <algorithm>
+#include <cmath>
 
 namespace irr
 {


### PR DESCRIPTION
Fixes https://travis-ci.org/edo9300/ygopro/jobs/571948396#L1326