### PR TITLE
Reduce Travis jobs for macOS to 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,24 +57,11 @@ matrix:
     - DEPLOY_BRANCH=travis-linux
   - name: "Mojave"
     os: osx
-    osx_image: xcode10.2
-    env: DEPLOY_BRANCH=travis-mojave
-  - name: "High Sierra"
-    os: osx
-    osx_image: xcode9.4
-    env: DEPLOY_BRANCH=travis-high-sierra
-  - name: "Sierra"
-    os: osx
-    osx_image: xcode9.2
-    env: DEPLOY_BRANCH=travis-sierra
-  - name: "El Capitan"
-    os: osx
-    osx_image: xcode8
-    env: DEPLOY_BRANCH=travis-el-capitan
-  allow_failures:
-  - name: "Sierra"
-  - name: "El Capitan"
-  fast_finish: true
+    osx_image: xcode10.3
+    env: 
+    - MACOSX_DEPLOYMENT_TARGET=10.11
+    - SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk"
+    - DEPLOY_BRANCH=travis-macOS
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./build-support/install-windows-bin.sh; fi  
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./build-support/install-ubuntu-bin.sh; fi
@@ -91,6 +78,7 @@ install:
     fi; 
   fi 
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
+    ./build-support/install-macOS-sdk.sh $MACOSX_DEPLOYMENT_TARGET;
     if [[ -f cache/libIrrlicht.a ]]; then 
       sudo cp -r cache/irrlicht /usr/local/include &&
       sudo cp cache/lua.h cache/luaconf.h cache/lualib.h cache/lauxlib.h cache/lua.hpp /usr/local/include &&

--- a/build-support/install-macOS-src.sh
+++ b/build-support/install-macOS-src.sh
@@ -6,7 +6,7 @@ curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-nam
 7z x irrlicht-1.8.4.zip
 cd irrlicht-1.8.4
 /usr/local/opt/gpatch/bin/patch -p0 --binary -i ../irrlicht-macOS.patch
-xcodebuild -project source/Irrlicht/MacOSX/MacOSX.xcodeproj -configuration Release -target libIrrlicht.a SYMROOT=build
+xcodebuild -project source/Irrlicht/MacOSX/MacOSX.xcodeproj -configuration Release -target libIrrlicht.a SYMROOT=build -sdk $SDKROOT -parallelizeTargets
 sudo mkdir -p /usr/local/include/irrlicht
 sudo cp -r include/*.h /usr/local/include/irrlicht
 sudo cp source/Irrlicht/MacOSX/build/Release/libIrrlicht.a /usr/local/lib
@@ -16,5 +16,5 @@ cd /tmp
 curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://www.lua.org/ftp/lua-5.3.5.tar.gz
 tar xf lua-5.3.5.tar.gz
 cd lua-5.3.5
-make macosx CC=g++
+make -j2 macosx CC=g++
 sudo make install

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -37,15 +37,6 @@ local ygopro_config=function(static_core)
 		excludes "COSOperator.*"
 		links { "sqlite3", "event", "fmt", "event_pthreads", "dl", "pthread", "git2", "curl" }
 
-	filter "system:bsd"
-		defines "LUA_USE_POSIX"
-		includedirs { "/usr/include/freetype2", "/usr/include/irrlicht" }
-		linkoptions { "-Wl,-rpath=./" }
-		links "GL"
-		if static_core then
-			links  "lua5.3-c++"
-		end
-
 	filter "system:macosx"
 		defines "LUA_USE_MACOSX"
 		includedirs { "/usr/local/include/freetype2", "/usr/local/include/irrlicht" }

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -7,6 +7,7 @@ local ygopro_config=function(static_core)
 	end
 	defines { "YGOPRO_USE_IRRKLANG", "CURL_STATICLIB" }
 	kind "WindowedApp"
+	cppdialect "C++14"
 	files { "**.cpp", "**.cc", "**.c", "**.h" }
 	excludes "lzma/**"
 	includedirs { "../ocgcore", "../irrKlang/include" }
@@ -30,7 +31,7 @@ local ygopro_config=function(static_core)
 		libdirs "../irrKlang/lib/Win32-gcc"
 
 	filter "action:not vs*"
-		buildoptions { "-std=c++14", "-fno-rtti", "-fpermissive" }
+		buildoptions { "-fno-rtti", "-fpermissive" }
 
 	filter "system:not windows"
 		defines "LUA_COMPAT_5_2"

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -39,10 +39,11 @@ local ygopro_config=function(static_core)
 
 	filter "system:macosx"
 		defines "LUA_USE_MACOSX"
+		buildoptions { "-fms-extensions" }
 		includedirs { "/usr/local/include/freetype2", "/usr/local/include/irrlicht" }
 		linkoptions { "-Wl,-rpath ./" }
 		libdirs "../irrKlang/bin/macosx-gcc/"
-		links "OpenGL.framework"
+		links { "Cocoa.framework", "IOKit.framework", "OpenGL.framework" }
 		if static_core then
 			links  "lua"
 		end

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,6 +1,6 @@
 newoption {
-	trigger		= "no-direct3d",
-	description	= "Disable DirectX options in irrlicht if the DirectX SDK isn't installed"
+	trigger	= "no-direct3d",
+	description = "Disable DirectX options in irrlicht if the DirectX SDK isn't installed"
 }
 newoption {
 	trigger = "pics",
@@ -25,11 +25,8 @@ workspace "ygo"
 		defines { "WIN32", "_WIN32", "NOMINMAX" }
 
 	filter "system:macosx"
-		toolset "clang"
-		buildoptions { "-fms-extensions" }
 		includedirs { "/usr/local/include" }
 		libdirs { "/usr/local/lib" }
-		links { "Cocoa.framework", "IOKit.framework", "OpenGL.framework" }
 
 	filter "action:vs*"
 		vectorextensions "SSE2"

--- a/premake5.lua
+++ b/premake5.lua
@@ -24,10 +24,6 @@ workspace "ygo"
 	filter "system:windows"
 		defines { "WIN32", "_WIN32", "NOMINMAX" }
 
-	filter "system:bsd"
-		includedirs "/usr/local/include"
-		libdirs "/usr/local/lib"
-
 	filter "system:macosx"
 		toolset "clang"
 		buildoptions { "-fms-extensions" }


### PR DESCRIPTION
- Target El Capitan
- Target El Capitan SDK
- The above apply to irrlicht and lua as well
- Reduce Travis jobs for macOS to 1
- Moved irrlicht-specific premake config to gframe so core stops getting unnecessary links
- Using `cppdialect` in premake; removed untested BSD configuration

Closes #24 by SDK target, which only affected Mojave clients
Unresolved: `_clock_gettime` not found on 10.11; `libevent` choking (cc #35)