### PR TITLE
[macOS] Build libevent from source, targeting 10.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,12 @@ install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
     ./build-support/install-macOS-sdk.sh $MACOSX_DEPLOYMENT_TARGET;
     if [[ -f cache/libIrrlicht.a ]]; then 
-      sudo cp -r cache/irrlicht /usr/local/include &&
-      sudo cp cache/lua.h cache/luaconf.h cache/lualib.h cache/lauxlib.h cache/lua.hpp /usr/local/include &&
-      sudo cp cache/*.a /usr/local/lib &&
-      rm -rf cache && echo "Loaded irrlicht and lua-c++ from cache.";
+      cp -r cache/irrlicht /usr/local/include &&
+      cp cache/lua.h cache/luaconf.h cache/lualib.h cache/lauxlib.h cache/lua.hpp /usr/local/include &&
+      cp cache/*.a /usr/local/lib &&
+      rm -rf /usr/local/Cellar/libevent/2.1.11 &&
+      cp -r cache/libevent /usr/local/Cellar/libevent/2.1.11 &&
+      rm -rf cache && echo "Loaded irrlicht, lua-c++, libevent from cache.";
     else
       ./build-support/install-macOS-src.sh; 
     fi ;
@@ -128,7 +130,8 @@ before_cache:
     cp -r /usr/local/include/irrlicht cache/irrlicht &&
     cp /usr/local/lib/libIrrlicht.a cache/libIrrlicht.a &&
     cp /usr/local/include/lua.h /usr/local/include/luaconf.h /usr/local/include/lualib.h /usr/local/include/lauxlib.h /usr/local/include/lua.hpp cache &&
-    cp /usr/local/lib/liblua.a cache/liblua.a;
+    cp /usr/local/lib/liblua.a cache/liblua.a &&
+    cp -r /usr/local/Cellar/libevent/2.1.11 cache/libevent;
   fi
 cache:
   directories:

--- a/build-support/install-macOS-src.sh
+++ b/build-support/install-macOS-src.sh
@@ -18,3 +18,12 @@ tar xf lua-5.3.5.tar.gz
 cd lua-5.3.5
 make -j2 macosx CC=g++
 sudo make install
+
+# Install libevent from source due to binary compatibility issues with 10.13 and earlier
+cd /tmp
+curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz
+tar xf libevent-2.1.11-stable.tar.gz
+cd libevent-2.1.11-stable
+./configure --prefix /usr/local/Cellar/libevent/2.1.11
+make -j2
+make install


### PR DESCRIPTION
Resolves last macOS backward-compatibility issues.
`libevent` is preinstalled on Travis, but we still install to guarantee the linkage for 2.1.11, then we overwrite the binaries with the correctly-targeted ones.

Closes #35 
- "Join" gets stuck on LAN mode on Sierra and High Sierra
- LAN mode crashes on El Capitan with `_clock_gettime Symbol not found`
- [Related](https://forum.qt.io/topic/78526/symbol-not-found-_clock_gettime-on-macos-10-11/4) [notes](https://github.com/pocoproject/poco/issues/1453)

(squash this PR as it's just one commit)