### PR TITLE
Fix Linux binary compatibility with vcpkg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,10 @@ addons:
     update: true
     packages:
     - p7zip-full 
-    - libevent-dev 
     - libfreetype6-dev
     - libirrlicht-dev 
-    - libsqlite3-dev 
     - libgl1-mesa-dev 
     - libglu-dev 
-    - libgit2-dev
   homebrew:
     update: true
     packages:
@@ -43,11 +40,13 @@ matrix:
     - VCPKG_CACHE_ZIP_URL=https://github.com/kevinlul/edopro-vcpkg-cache/raw/master/installed.zip
     - DXSDK_DIR=/c/d3d9sdk/
     - DEPLOY_BRANCH=travis-windows
-    cache: false
   - name: "Bionic GCC7"
     os: linux
     compiler: gcc  
     env:
+    - VCPKG_ROOT=./vcpkg
+    - VCPKG_LIBS="lua libevent sqlite3 fmt nlohmann-json curl libgit2"
+    - VCPKG_CACHE_ZIP_URL=https://github.com/kevinlul/edopro-vcpkg-cache/raw/master/installed-linux.7z
     - DEPLOY_BRANCH=travis-linux
   - name: "Mojave"
     os: osx
@@ -56,6 +55,9 @@ matrix:
     - MACOSX_DEPLOYMENT_TARGET=10.11
     - SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk"
     - DEPLOY_BRANCH=travis-macOS
+    cache:
+      directories:
+      - cache
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./build-support/install-windows-bin.sh; fi  
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./build-support/install-ubuntu-bin.sh; fi
@@ -66,11 +68,7 @@ install:
     ./build-support/install-windows-d3d9sdk.sh;
   fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then 
-    if [[ -f cache/lib/libfmt.a ]]; then 
-      sudo cp -r cache/* /usr/local/ && rm -rf cache && echo "Loaded fmt and nlohmann-json from cache.";   
-    else
-      ./build-support/install-ubuntu-src.sh;
-    fi; 
+    ./build-support/install-linux-vcpkg-cache.sh;
   fi 
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
     ./build-support/install-macOS-sdk.sh $MACOSX_DEPLOYMENT_TARGET;
@@ -89,7 +87,12 @@ script:
 - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     ./premake5 vs2017 --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\";
     "$MSBUILD_PATH/msbuild.exe" -m -p:Configuration=$BUILD_CONFIG ./build/ygo.sln;
-  else
+  fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    ./premake5 gmake2 --vcpkg-root=$VCPKG_ROOT --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\";
+    make -Cbuild -j2 config=$BUILD_CONFIG;
+  fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     ./premake5 gmake2 --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\";
     make -Cbuild -j2 config=$BUILD_CONFIG;
   fi
@@ -112,16 +115,6 @@ deploy:
   on:
     condition: "$TRAVIS_OS_NAME != windows"
 before_cache:
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    mkdir -p cache/include && mkdir -p cache/lib/cmake &&
-    cp -r /usr/local/lib/cmake/fmt cache/lib/cmake/fmt &&
-    cp -r /usr/local/lib/pkgconfig cache/lib/pkgconfig &&
-    cp /usr/local/lib/libfmt.a cache/lib/libfmt.a &&
-    cp -r /usr/local/include/fmt cache/include/fmt &&
-    cp /usr/local/include/lua.h /usr/local/include/luaconf.h /usr/local/include/lualib.h /usr/local/include/lauxlib.h /usr/local/include/lua.hpp cache/include &&
-    cp /usr/local/lib/liblua.a cache/lib/liblua.a &&
-    cp -r /usr/local/include/nlohmann cache/include/nlohmann; 
-  fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     mkdir -p cache &&
     cp -r /usr/local/include/irrlicht cache/irrlicht &&
@@ -130,6 +123,3 @@ before_cache:
     cp /usr/local/lib/liblua.a cache/liblua.a &&
     cp -r /usr/local/Cellar/libevent/2.1.11 cache/libevent;
   fi
-cache:
-  directories:
-  - cache

--- a/build-support/deploy-ubuntu.sh
+++ b/build-support/deploy-ubuntu.sh
@@ -10,8 +10,6 @@ if [[ "$BUILD_CONFIG" -ne "debug" ]]; then
     strip deploy/ygoprodll
 fi
 cp irrKlang/bin/linux-gcc-64/libIrrKlang.so deploy/
-# Stopgap measure for Travis builds
-cp /usr/lib/x86_64-linux-gnu/libgit2.so.26 deploy/
 cp *.conf deploy/
 cp *.json deploy/
 if [[ ! -d deploy/textures ]]; then cp -r textures deploy/; fi

--- a/build-support/install-linux-vcpkg-cache.sh
+++ b/build-support/install-linux-vcpkg-cache.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+mkdir -p "$VCPKG_ROOT"
+cd "$VCPKG_ROOT"
+curl --retry 5 --connect-timeout 30 --location --remote-header-name --output installed.7z $VCPKG_CACHE_ZIP_URL
+7z x installed.7z

--- a/build-support/install-macOS-src.sh
+++ b/build-support/install-macOS-src.sh
@@ -16,7 +16,7 @@ cd /tmp
 curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://www.lua.org/ftp/lua-5.3.5.tar.gz
 tar xf lua-5.3.5.tar.gz
 cd lua-5.3.5
-make -j2 macosx CC=$CXX
+make -j2 macosx
 sudo make install
 
 # Install libevent from source due to binary compatibility issues with 10.13 and earlier

--- a/build-support/install-ubuntu-src.sh
+++ b/build-support/install-ubuntu-src.sh
@@ -14,7 +14,7 @@ cd /tmp
 curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://www.lua.org/ftp/lua-5.3.5.tar.gz
 tar xf lua-5.3.5.tar.gz
 cd lua-5.3.5
-make -j2 linux CC=$CXX MYCFLAGS=-fPIC
+make -j2 linux MYCFLAGS=-fPIC
 sudo make install
 
 sudo mkdir -p /usr/local/include/nlohmann

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -58,6 +58,9 @@ local ygopro_config=function(static_core)
 		if static_core then
 			links  "lua:static"
 		end
+		if _OPTIONS["vcpkg-root"] then
+			links { "ssl", "crypto", "z" }
+		end
 end
 
 include "lzma/."

--- a/premake5.lua
+++ b/premake5.lua
@@ -17,6 +17,11 @@ newoption {
 	value = "path",
 	description = "Path to library folder containing libocgcore"
 }
+newoption {
+	trigger = "vcpkg-root",
+	value = "path",
+	description = "Path to vcpkg installation"
+}
 workspace "ygo"
 	location "build"
 	language "C++"
@@ -32,6 +37,17 @@ workspace "ygo"
 	filter "system:macosx"
 		includedirs { "/usr/local/include" }
 		libdirs { "/usr/local/lib" }
+
+	if _OPTIONS["vcpkg-root"] then
+		filter "system:linux"
+			includedirs { _OPTIONS["vcpkg-root"] .. "/installed/x64-linux/include" }
+	
+		filter { "system:linux", "configurations:Debug" }
+			libdirs { _OPTIONS["vcpkg-root"] .. "/installed/x64-linux/debug/lib" }
+	
+		filter { "system:linux", "configurations:Release" }
+			libdirs { _OPTIONS["vcpkg-root"] .. "/installed/x64-linux/lib" }
+	end
 
 	filter "action:vs*"
 		vectorextensions "SSE2"
@@ -53,7 +69,6 @@ workspace "ygo"
 	filter { "configurations:Release*" , "action:not vs*" }
 		symbols "On"
 		defines "NDEBUG"
-		buildoptions "-march=native"
 
 	filter "configurations:Release"
 		optimize "Size"


### PR DESCRIPTION
Update ocgcore pointer and switch to Lua with C linkage.
Add `vcpkg-root` build option to premake for use on Linux.
Use precompiled vcpkg for Linux build with most dependencies except `freetype` and `irrlicht`

Before merging: please reset Travis cache!