### PR TITLE
Add OpenAL support, enabled with `--no-irrklang` option to premake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ addons:
     - libgit2
     - fmt
     - nlohmann-json
+    - openal-soft
+    - mpg123
+    - libsndfile
 matrix:
   include:
   - name: "Windows 10"

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2679,7 +2679,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_SUMMONING: {
 		unsigned int code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
-		/*loc_info info = */ClientCard::read_location_info(pbuf);
+		/*CoreUtils::loc_info info = */CoreUtils::ReadLocInfo(pbuf);
 		if(!mainGame->soundManager->PlayChant(code))
 			mainGame->soundManager->PlaySoundEffect(SoundManager::SFX::SUMMON);
 		if(!mainGame->dInfo.isCatchingUp) {
@@ -2700,7 +2700,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_SPSUMMONING: {
 		unsigned int code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
-		/*loc_info info = */ClientCard::read_location_info(pbuf);
+		/*CoreUtils::loc_info info = */CoreUtils::ReadLocInfo(pbuf);
 		if(!mainGame->soundManager->PlayChant(code))
 			mainGame->soundManager->PlaySoundEffect(SoundManager::SFX::SPECIAL_SUMMON);
 		if(!mainGame->dInfo.isCatchingUp) {
@@ -3007,8 +3007,8 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_EQUIP: {
 		mainGame->soundManager->PlaySoundEffect(SoundManager::SFX::EQUIP);
-		loc_info info1 = ClientCard::read_location_info(pbuf);
-		loc_info info2 = ClientCard::read_location_info(pbuf);
+		CoreUtils::loc_info info1 = CoreUtils::ReadLocInfo(pbuf);
+		CoreUtils::loc_info info2 = CoreUtils::ReadLocInfo(pbuf);
 		ClientCard* pc1 = mainGame->dField.GetCard(mainGame->LocalPlayer(info1.controler), info1.location, info1.sequence);
 		ClientCard* pc2 = mainGame->dField.GetCard(mainGame->LocalPlayer(info2.controler), info2.location, info2.sequence);
 		if(mainGame->dInfo.isCatchingUp) {
@@ -3182,7 +3182,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_ATTACK: {
 		mainGame->soundManager->PlaySoundEffect(SoundManager::SFX::ATTACK);
-		loc_info info1 = ClientCard::read_location_info(pbuf);
+		CoreUtils::loc_info info1 = CoreUtils::ReadLocInfo(pbuf);
 		info1.controler = mainGame->LocalPlayer(info1.controler);
 		mainGame->dField.attacker = mainGame->dField.GetCard(info1.controler, info1.location, info1.sequence);
 		CoreUtils::loc_info info2 = CoreUtils::ReadLocInfo(pbuf);

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -5,7 +5,6 @@
 #include "game.h"
 #include "duelclient.h"
 #include "data_manager.h"
-#include "sound_manager.h"
 #include "image_manager.h"
 #include "replay_mode.h"
 #include "single_mode.h"
@@ -1798,8 +1797,8 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 			switch(id) {
 			case SCROLL_VOLUME: {
 				mainGame->gameConf.volume = (double)mainGame->scrVolume->getPos() / 100;
-				soundManager.SetSoundVolume(mainGame->gameConf.volume);
-				soundManager.SetMusicVolume(mainGame->gameConf.volume);
+				mainGame->soundManager->SetSoundVolume(mainGame->gameConf.volume);
+				mainGame->soundManager->SetMusicVolume(mainGame->gameConf.volume);
 				return true;
 			}
 			}
@@ -1808,11 +1807,11 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 		case irr::gui::EGET_CHECKBOX_CHANGED: {
 			switch (id) {
 			case CHECKBOX_ENABLE_MUSIC: {
-				soundManager.EnableMusic(mainGame->chkEnableMusic->isChecked());
+				mainGame->soundManager->EnableMusic(mainGame->chkEnableMusic->isChecked());
 				return true;
 			}
 			case CHECKBOX_ENABLE_SOUND: {
-				soundManager.EnableSounds(mainGame->chkEnableSound->isChecked());
+				mainGame->soundManager->EnableSounds(mainGame->chkEnableSound->isChecked());
 				return true;
 			}
 			case CHECKBOX_QUICK_ANIMATION: {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -782,7 +782,8 @@ bool Game::Initialize() {
 	stCardListTip->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 	stCardListTip->setVisible(false);
 	device->setEventReceiver(&menuHandler);
-	if(!soundManager.Init(gameConf.volume, gameConf.volume, gameConf.enablesound, gameConf.enablemusic, nullptr)) {
+	soundManager = std::make_unique<SoundManager>();
+	if(!soundManager->Init(gameConf.volume, gameConf.volume, gameConf.enablesound, gameConf.enablemusic, nullptr)) {
 		chkEnableSound->setChecked(false);
 		chkEnableSound->setEnabled(false);
 		chkEnableSound->setVisible(false);
@@ -941,15 +942,15 @@ void Game::MainLoop() {
 		gMutex.lock();
 		if(dInfo.isInDuel) {
 			if (showcardcode == 1 || showcardcode == 3)
-				soundManager.PlayBGM(SoundManager::BGM::WIN);
+				soundManager->PlayBGM(SoundManager::BGM::WIN);
 			else if (showcardcode == 2)
-				soundManager.PlayBGM(SoundManager::BGM::LOSE);
+				soundManager->PlayBGM(SoundManager::BGM::LOSE);
 			else if (dInfo.lp[0] > 0 && dInfo.lp[LocalPlayer(0)] <= dInfo.lp[LocalPlayer(1)] / 2)
-				soundManager.PlayBGM(SoundManager::BGM::DISADVANTAGE);
+				soundManager->PlayBGM(SoundManager::BGM::DISADVANTAGE);
 			else if (dInfo.lp[0] > 0 && dInfo.lp[LocalPlayer(0)] >= dInfo.lp[LocalPlayer(1)] * 2)
-				soundManager.PlayBGM(SoundManager::BGM::ADVANTAGE);
+				soundManager->PlayBGM(SoundManager::BGM::ADVANTAGE);
 			else
-				soundManager.PlayBGM(SoundManager::BGM::DUEL);
+				soundManager->PlayBGM(SoundManager::BGM::DUEL);
 			DrawBackImage(imageManager.tBackGround);
 			DrawBackGround();
 			DrawCards();
@@ -958,11 +959,11 @@ void Game::MainLoop() {
 			driver->setMaterial(irr::video::IdentityMaterial);
 			driver->clearZBuffer();
 		} else if(is_building) {
-			soundManager.PlayBGM(SoundManager::BGM::DECK);
+			soundManager->PlayBGM(SoundManager::BGM::DECK);
 			DrawBackImage(imageManager.tBackGround_deck);
 			DrawDeckBd();
 		} else {
-			soundManager.PlayBGM(SoundManager::BGM::MENU);
+			soundManager->PlayBGM(SoundManager::BGM::MENU);
 			DrawBackImage(imageManager.tBackGround_menu);
 		}
 		DrawGUI();
@@ -1481,10 +1482,10 @@ void Game::AddChatMsg(const std::wstring& msg, int player, int type) {
 	chatTiming[0] = 1200.0f;
 	chatType[0] = player;
 	if(type == 0) {
-		soundManager.PlaySoundEffect(SoundManager::SFX::CHAT);
+		soundManager->PlaySoundEffect(SoundManager::SFX::CHAT);
 		chatMsg[0].append(dInfo.hostname[player]);
 	} else if(type == 1) {
-		soundManager.PlaySoundEffect(SoundManager::SFX::CHAT);
+		soundManager->PlaySoundEffect(SoundManager::SFX::CHAT);
 		chatMsg[0].append(dInfo.clientname[player]);
 	} else if(type == 2) {
 		switch(player) {
@@ -1492,7 +1493,7 @@ void Game::AddChatMsg(const std::wstring& msg, int player, int type) {
 			chatMsg[0].append(ebNickName->getText());
 			break;
 		case 8: //system custom message, no prefix.
-			soundManager.PlaySoundEffect(SoundManager::SFX::CHAT);
+			soundManager->PlaySoundEffect(SoundManager::SFX::CHAT);
 			chatMsg[0].append(L"[System]");
 			break;
 		case 9: //error message

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -20,6 +20,7 @@
 #include "CProgressBar/CProgressBar.h"
 #include "ResizeablePanel/ResizeablePanel.h"
 #include "deck_manager.h"
+#include "sound_manager.h"
 #include "repo_manager.h"
 
 namespace ygo {
@@ -202,6 +203,7 @@ public:
 	static int ScriptReader(void* payload, OCG_Duel duel, const char* name);
 	static void MessageHandler(void* payload, const char* string, int type);
 
+	std::unique_ptr<SoundManager> soundManager;
 	std::mutex gMutex;
 	std::mutex analyzeMutex;
 	Signal frameSignal;

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -52,6 +52,11 @@ local ygopro_config=function(static_core)
 			links  "lua"
 		end
 
+	filter { "system:macosx", "options:no-irrklang" }
+		includedirs "/usr/local/opt/openal-soft/include"
+		libdirs "/usr/local/opt/openal-soft/lib"
+		links "openal"
+
 	filter "system:linux"
 		defines "LUA_USE_LINUX"
 		includedirs { "/usr/include/freetype2", "/usr/include/irrlicht" }

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -43,7 +43,7 @@ local ygopro_config=function(static_core)
 		links { "sqlite3", "event", "event_pthreads", "dl", "pthread", "git2" }
 
 	filter { "system:not windows", "options:no-irrklang" }
-		links { "openal", "mpg123" }
+		links { "openal", "mpg123", "sndfile", "vorbis", "vorbisenc", "ogg", "FLAC" }
 
 	filter "system:macosx"
 		defines "LUA_USE_MACOSX"

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -5,13 +5,16 @@ local ygopro_config=function(static_core)
 	if _OPTIONS["fields"] then
 		defines { "DEFAULT_FIELD_URL=" .. _OPTIONS["fields"] }
 	end
-	defines { "YGOPRO_USE_IRRKLANG", "CURL_STATICLIB" }
 	kind "WindowedApp"
 	cppdialect "C++14"
 	files { "**.cpp", "**.cc", "**.c", "**.h" }
 	excludes "lzma/**"
 	includedirs { "../ocgcore", "../irrKlang/include" }
 	links { "clzma", "freetype", "Irrlicht", "IrrKlang" }
+	defines "CURL_STATICLIB"
+	filter "options:not no-irrklang"
+		defines "YGOPRO_USE_IRRKLANG"
+
 	filter "system:windows"
 		kind "ConsoleApp"
 		files "ygopro.rc"

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -43,7 +43,7 @@ local ygopro_config=function(static_core)
 		links { "sqlite3", "event", "event_pthreads", "dl", "pthread", "git2" }
 
 	filter { "system:not windows", "options:no-irrklang" }
-		links "openal"
+		links { "openal", "mpg123" }
 
 	filter "system:macosx"
 		defines "LUA_USE_MACOSX"

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -9,11 +9,12 @@ local ygopro_config=function(static_core)
 	cppdialect "C++14"
 	files { "**.cpp", "**.cc", "**.c", "**.h" }
 	excludes "lzma/**"
-	includedirs { "../ocgcore", "../irrKlang/include" }
-	links { "clzma", "freetype", "Irrlicht", "IrrKlang" }
 	defines "CURL_STATICLIB"
+	includedirs { "../ocgcore", "../irrKlang/include" }
+	links { "clzma", "freetype", "Irrlicht" }
 	filter "options:not no-irrklang"
 		defines "YGOPRO_USE_IRRKLANG"
+		links "IrrKlang"
 
 	filter "system:windows"
 		kind "ConsoleApp"
@@ -39,7 +40,10 @@ local ygopro_config=function(static_core)
 	filter "system:not windows"
 		defines "LUA_COMPAT_5_2"
 		excludes "COSOperator.*"
-		links { "sqlite3", "event", "fmt", "event_pthreads", "dl", "pthread", "git2", "curl" }
+		links { "sqlite3", "event", "event_pthreads", "dl", "pthread", "git2" }
+
+	filter { "system:not windows", "options:no-irrklang" }
+		links "openal"
 
 	filter "system:macosx"
 		defines "LUA_USE_MACOSX"
@@ -47,7 +51,7 @@ local ygopro_config=function(static_core)
 		includedirs { "/usr/local/include/freetype2", "/usr/local/include/irrlicht" }
 		linkoptions { "-Wl,-rpath ./" }
 		libdirs "../irrKlang/bin/macosx-gcc/"
-		links { "Cocoa.framework", "IOKit.framework", "OpenGL.framework" }
+		links { "fmt", "curl", "Cocoa.framework", "IOKit.framework", "OpenGL.framework" }
 		if static_core then
 			links  "lua"
 		end
@@ -55,7 +59,12 @@ local ygopro_config=function(static_core)
 	filter { "system:macosx", "options:no-irrklang" }
 		includedirs "/usr/local/opt/openal-soft/include"
 		libdirs "/usr/local/opt/openal-soft/lib"
-		links "openal"
+
+	filter { "system:linux", "configurations:Debug" }
+		links { "fmtd", "curl-d" }
+
+        filter { "system:linux", "configurations:Release" }
+		links { "fmt", "curl" }	
 
 	filter "system:linux"
 		defines "LUA_USE_LINUX"

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -128,16 +128,18 @@ void SoundManager::PlayMusic(const std::string& song, bool loop) {
 #endif
 }
 void SoundManager::PlayBGM(BGM scene) {
-#ifdef YGOPRO_USE_IRRKLANG
 	auto& list = BGMList[scene];
 	int count = list.size();
+#ifdef YGOPRO_USE_IRRKLANG
 	if(musicEnabled && (scene != bgm_scene || (soundBGM && soundBGM->isFinished()) || !soundBGM) && count > 0) {
+#else
+	if (musicEnabled && scene != bgm_scene && count > 0) {
+#endif
 		bgm_scene = scene;
 		int bgm = (std::uniform_int_distribution<>(0, count - 1))(rnd);
 		std::string BGMName = "./sound/BGM/" + list[bgm];
 		PlayMusic(BGMName, true);
 	}
-#endif
 }
 void SoundManager::StopBGM() {
 #ifdef YGOPRO_USE_IRRKLANG

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -124,7 +124,8 @@ void SoundManager::PlayMusic(const std::string& song, bool loop) {
 		soundBGM = soundEngine->play2D(song.c_str(), loop, false, true);
 	}
 #else
-    bgm->play(song, loop);
+    StopBGM();
+    bgmCurrent = bgm->play(song, loop);
 #endif
 }
 void SoundManager::PlayBGM(BGM scene) {
@@ -133,8 +134,7 @@ void SoundManager::PlayBGM(BGM scene) {
 #ifdef YGOPRO_USE_IRRKLANG
 	if(musicEnabled && (scene != bgm_scene || (soundBGM && soundBGM->isFinished()) || !soundBGM) && count > 0) {
 #else
-	if (musicEnabled && scene != bgm_scene && count > 0) {
-        StopBGM();
+	if (musicEnabled && (scene != bgm_scene || !bgm->exists(bgmCurrent)) && count > 0) {
 #endif
 		bgm_scene = scene;
 		int bgm = (std::uniform_int_distribution<>(0, count - 1))(rnd);
@@ -193,9 +193,10 @@ void SoundManager::EnableMusic(bool enable) {
 			soundBGM->drop();
 			soundBGM = nullptr;
 		}
-#endif
+#else
         StopBGM();
-	}
+#endif
+    }
 }
 
 } // namespace ygo

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -16,7 +16,7 @@ bool SoundManager::Init(double sounds_volume, double music_volume, bool sounds_e
 #ifdef YGOPRO_USE_IRRKLANG
 	soundEngine = irrklang::createIrrKlangDevice();
 	if(!soundEngine) {
-		return false;
+		return soundsEnabled = musicEnabled = false;
 	} else {
 #ifdef IRRKLANG_STATIC
 		irrklang::ikpMP3Init(soundEngine);
@@ -34,7 +34,7 @@ bool SoundManager::Init(double sounds_volume, double music_volume, bool sounds_e
         return true;
     }
     catch (std::runtime_error& e) {
-        return false;
+        return soundsEnabled = musicEnabled = false;
     }
 #endif // YGOPRO_USE_IRRKLANG
 }
@@ -109,9 +109,9 @@ void SoundManager::PlaySoundEffect(SFX sound) {
     };
     if (!soundsEnabled) return;
 #ifdef YGOPRO_USE_IRRKLANG
-    soundEngine->play2D(fx.at(sound));
+    if (soundEngine) soundEngine->play2D(fx.at(sound));
 #else
-    sfx->play(fx.at(sound), false);
+    if (sfx) sfx->play(fx.at(sound), false);
 #endif
 }
 void SoundManager::PlayMusic(const std::string& song, bool loop) {
@@ -119,11 +119,11 @@ void SoundManager::PlayMusic(const std::string& song, bool loop) {
 #ifdef YGOPRO_USE_IRRKLANG
 	if(!soundBGM || soundBGM->getSoundSource()->getName() != song) {
         StopBGM();
-		soundBGM = soundEngine->play2D(song.c_str(), loop, false, true);
+		if (soundEngine) soundBGM = soundEngine->play2D(song.c_str(), loop, false, true);
 	}
 #else
     StopBGM();
-    bgmCurrent = bgm->play(song, loop);
+    if (bgm) bgmCurrent = bgm->play(song, loop);
 #endif
 }
 void SoundManager::PlayBGM(BGM scene) {
@@ -152,13 +152,12 @@ void SoundManager::StopBGM() {
 #endif
 }
 bool SoundManager::PlayChant(unsigned int code) {
-
 	if(ChantsList.count(code)) {
 #ifdef YGOPRO_USE_IRRKLANG
-		if(!soundEngine->isCurrentlyPlaying(("./sound/chants/" + ChantsList[code]).c_str()))
+		if (soundEngine && !soundEngine->isCurrentlyPlaying(("./sound/chants/" + ChantsList[code]).c_str()))
 			soundEngine->play2D(("./sound/chants/" + ChantsList[code]).c_str());
 #else
-        bgm->play("./sound/chants/" + ChantsList[code], false);
+        if (bgm) bgm->play("./sound/chants/" + ChantsList[code], false);
 #endif
 		return true;
 	}
@@ -166,16 +165,16 @@ bool SoundManager::PlayChant(unsigned int code) {
 }
 void SoundManager::SetSoundVolume(double volume) {
 #ifdef YGOPRO_USE_IRRKLANG
-	soundEngine->setSoundVolume(volume);
+	if (soundEngine) soundEngine->setSoundVolume(volume);
 #else
-    sfx->setVolume(volume);
+    if (sfx) sfx->setVolume(volume);
 #endif
 }
 void SoundManager::SetMusicVolume(double volume) {
 #ifdef YGOPRO_USE_IRRKLANG
-	soundEngine->setSoundVolume(volume);
+	if (soundEngine) soundEngine->setSoundVolume(volume);
 #else
-    bgm->setVolume(volume);
+    if (bgm) bgm->setVolume(volume);
 #endif
 }
 void SoundManager::EnableSounds(bool enable) {

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -28,7 +28,8 @@ bool SoundManager::Init(double sounds_volume, double music_volume, bool sounds_e
 	}
 #else
     try {
-        alSound = std::make_unique<YGOpen::OpenALSoundEngine>();
+        openal = std::make_unique<YGOpen::OpenALSingleton>();
+        sfx = std::make_unique<YGOpen::OpenALSoundLayer>(openal);
         return true;
     }
     catch (std::runtime_error& e) {
@@ -109,7 +110,7 @@ void SoundManager::PlaySoundEffect(SFX sound) {
 #ifdef YGOPRO_USE_IRRKLANG
     soundEngine->play2D(fx.at(sound));
 #else
-    alSound->play(fx.at(sound), false);
+    sfx->play(fx.at(sound), false);
 #endif
 }
 void SoundManager::PlayMusic(const std::string& song, bool loop) {
@@ -124,7 +125,7 @@ void SoundManager::PlayMusic(const std::string& song, bool loop) {
 		soundBGM = soundEngine->play2D(song.c_str(), loop, false, true);
 	}
 #else
-    alSound->play(song, loop);
+    sfx->play(song, loop);
 #endif
 }
 void SoundManager::PlayBGM(BGM scene) {
@@ -149,7 +150,7 @@ void SoundManager::StopBGM() {
 		soundBGM = nullptr;
 	}
 #else
-    alSound->stopAll();
+    sfx->stopAll();
 #endif
 }
 bool SoundManager::PlayChant(unsigned int code) {
@@ -159,7 +160,7 @@ bool SoundManager::PlayChant(unsigned int code) {
 		if(!soundEngine->isCurrentlyPlaying(("./sound/chants/" + ChantsList[code]).c_str()))
 			soundEngine->play2D(("./sound/chants/" + ChantsList[code]).c_str());
 #else
-        alSound->play("./sound/chants/" + ChantsList[code], false);
+        sfx->play("./sound/chants/" + ChantsList[code], false);
 #endif
 		return true;
 	}
@@ -169,14 +170,14 @@ void SoundManager::SetSoundVolume(double volume) {
 #ifdef YGOPRO_USE_IRRKLANG
 	soundEngine->setSoundVolume(volume);
 #else
-    alSound->setVolume(volume);
+    sfx->setVolume(volume);
 #endif
 }
 void SoundManager::SetMusicVolume(double volume) {
 #ifdef YGOPRO_USE_IRRKLANG
 	soundEngine->setSoundVolume(volume);
 #else
-    alSound->setVolume(volume);
+    sfx->setVolume(volume);
 #endif
 }
 void SoundManager::EnableSounds(bool enable) {
@@ -193,7 +194,7 @@ void SoundManager::EnableMusic(bool enable) {
 			soundBGM = nullptr;
 		}
 #endif
-        alSound->stopAll();
+        sfx->stopAll();
 	}
 }
 

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -6,8 +6,6 @@
 
 namespace ygo {
 
-SoundManager soundManager;
-
 bool SoundManager::Init(double sounds_volume, double music_volume, bool sounds_enabled, bool music_enabled, void* payload) {
 	soundsEnabled = sounds_enabled;
 	musicEnabled = music_enabled;

--- a/gframe/sound_manager.h
+++ b/gframe/sound_manager.h
@@ -50,7 +50,7 @@ public:
         LOSE
     };
 #ifndef YGOPRO_USE_IRRKLANG
-    SoundManager() : alSound(nullptr) {}
+    SoundManager() : openal(nullptr), sfx(nullptr) {}
 #endif
     ~SoundManager();
 	bool Init(double sounds_volume, double music_volume, bool sounds_enabled, bool music_enabled, void* payload = nullptr);
@@ -68,18 +68,19 @@ public:
 private:
     std::vector<std::string> BGMList[8];
     std::map<unsigned int, std::string> ChantsList;
-    int bgm_scene;
+    int bgm_scene = -1;
     std::mt19937 rnd;
 #ifdef YGOPRO_USE_IRRKLANG
     irrklang::ISoundEngine* soundEngine;
     irrklang::ISound* soundBGM;
 #else
-    std::unique_ptr<YGOpen::OpenALSoundEngine> alSound;
+    std::unique_ptr<YGOpen::OpenALSingleton> openal;
+    std::unique_ptr<YGOpen::OpenALSoundLayer> sfx;
 #endif
     void RefreshBGMDir(path_string path, BGM scene);
     void RefreshChantsList();
-    bool soundsEnabled;
-    bool musicEnabled;
+    bool soundsEnabled = false;
+    bool musicEnabled = false;
 };
 
 extern SoundManager soundManager;

--- a/gframe/sound_manager.h
+++ b/gframe/sound_manager.h
@@ -85,8 +85,6 @@ private:
     bool musicEnabled = false;
 };
 
-extern SoundManager soundManager;
-
 }
 
 #endif //SOUNDMANAGER_H

--- a/gframe/sound_manager.h
+++ b/gframe/sound_manager.h
@@ -1,9 +1,11 @@
 #ifndef SOUNDMANAGER_H
 #define SOUNDMANAGER_H
 
-#ifdef YGOPRO_USE_IRRKLANG
 #include <random>
+#ifdef YGOPRO_USE_IRRKLANG
 #include <irrKlang.h>
+#else
+#include "sound_openal.h"
 #endif
 #include "utils.h"
 
@@ -47,6 +49,9 @@ public:
         WIN,
         LOSE
     };
+#ifndef YGOPRO_USE_IRRKLANG
+    SoundManager() : alSound(nullptr) {}
+#endif
     ~SoundManager();
 	bool Init(double sounds_volume, double music_volume, bool sounds_enabled, bool music_enabled, void* payload = nullptr);
 	void RefreshBGMList();
@@ -64,10 +69,12 @@ private:
     std::vector<std::string> BGMList[8];
     std::map<unsigned int, std::string> ChantsList;
     int bgm_scene;
+    std::mt19937 rnd;
 #ifdef YGOPRO_USE_IRRKLANG
     irrklang::ISoundEngine* soundEngine;
     irrklang::ISound* soundBGM;
-    std::mt19937 rnd;
+#else
+    std::unique_ptr<YGOpen::OpenALSoundEngine> alSound;
 #endif
     void RefreshBGMDir(path_string path, BGM scene);
     void RefreshChantsList();

--- a/gframe/sound_manager.h
+++ b/gframe/sound_manager.h
@@ -76,6 +76,7 @@ private:
 #else
     std::unique_ptr<YGOpen::OpenALSingleton> openal;
     std::unique_ptr<YGOpen::OpenALSoundLayer> sfx;
+    std::unique_ptr<YGOpen::OpenALSoundLayer> bgm;
 #endif
     void RefreshBGMDir(path_string path, BGM scene);
     void RefreshChantsList();

--- a/gframe/sound_manager.h
+++ b/gframe/sound_manager.h
@@ -77,6 +77,7 @@ private:
     std::unique_ptr<YGOpen::OpenALSingleton> openal;
     std::unique_ptr<YGOpen::OpenALSoundLayer> sfx;
     std::unique_ptr<YGOpen::OpenALSoundLayer> bgm;
+    int bgmCurrent = -1;
 #endif
     void RefreshBGMDir(path_string path, BGM scene);
     void RefreshChantsList();

--- a/gframe/sound_openal.cpp
+++ b/gframe/sound_openal.cpp
@@ -36,12 +36,12 @@ OpenALSoundEngine::~OpenALSoundEngine() {
     }
 }
 
-typedef union array_int32 {
+union array_int32 {
     char c[4];
     int32_t i;
 };
 
-typedef union array_int16 {
+union array_int16 {
     char c[2];
     int16_t i;
 };
@@ -138,7 +138,7 @@ bool OpenALSoundEngine::load(const std::string& filename)
     if (ygo::Utils::GetFileExtension(filename) == "wav") {
         auto data = loadWav(filename);
         if (!data) return false;
-        buffers.insert_or_assign(filename, data);
+        buffers[filename] =  data;
         return true;
     }
     return false;

--- a/gframe/sound_openal.cpp
+++ b/gframe/sound_openal.cpp
@@ -1,5 +1,6 @@
 #include "sound_openal.h"
 #include <array>
+#include <iterator>
 #include "utils.h"
 
 namespace YGOpen {

--- a/gframe/sound_openal.cpp
+++ b/gframe/sound_openal.cpp
@@ -1,0 +1,224 @@
+#include "sound_openal.h"
+#include <array>
+#include "utils.h"
+
+namespace YGOpen {
+
+static void delete_ALCdevice(ALCdevice* ptr)
+{
+    if (ptr) {
+        alcCloseDevice(ptr);
+    }
+}
+static void delete_ALCcontext(ALCcontext* ptr)
+{
+    if (ptr) {
+        alcMakeContextCurrent(nullptr);
+        alcDestroyContext(ptr);
+    }
+}
+
+OpenALSoundEngine::OpenALSoundEngine() : device(nullptr, delete_ALCdevice), context(nullptr, delete_ALCcontext), buffers(), playing() {
+    device.reset(alcOpenDevice(nullptr));
+    if (!device) {
+        throw std::runtime_error("Failed to create OpenAL audio device!");
+    }
+    context.reset(alcCreateContext(device.get(), nullptr));
+    if (!alcMakeContextCurrent(context.get())) {
+        throw std::runtime_error("Failed to set OpenAL audio context!");
+    }
+}
+
+OpenALSoundEngine::~OpenALSoundEngine() {
+    stopAll();
+    for (const auto& iter : buffers) {
+        alDeleteBuffers(1, &iter.second->id);
+    }
+}
+
+typedef union array_int32 {
+    char c[4];
+    int32_t i;
+};
+
+typedef union array_int16 {
+    char c[2];
+    int16_t i;
+};
+
+static inline void read32(std::istream& in, array_int32& out) {
+    in.read(out.c, 4);
+}
+
+static inline void read16(std::istream& in, array_int16& out) {
+    in.read(out.c, 2);
+}
+
+static inline ALenum alUtilFormatFromWav(const int16_t channels, const int16_t bitsPerSample) {
+    if (channels == 1) {
+        if (bitsPerSample == 8) {
+            return AL_FORMAT_MONO8;
+        }
+        else { // Assume 16
+            return AL_FORMAT_MONO16;
+        }
+    }
+    else { // Assume 2
+        if (bitsPerSample == 8) {
+            return AL_FORMAT_STEREO8;
+        }
+        else { // Assume 16
+            return AL_FORMAT_STEREO16;
+        }
+    }
+}
+
+static constexpr std::array<char, 4> RIFF({ 'R','I','F','F' });
+static constexpr std::array<char, 4> WAVE({ 'W','A','V','E' });
+static constexpr std::array<char, 4> FMT_({ 'f','m','t',' ' });
+static constexpr std::array<char, 4> LIST({ 'L','I','S','T' });
+static constexpr std::array<char, 4> DATA({ 'd','a','t','a' });
+
+static std::shared_ptr<OpenALSoundBuffer> loadWav(const std::string& filename) {
+    std::array<char, 4> header;
+    array_int32 throwawayInt32;
+    std::array<char, 4> format;
+    std::array<char, 4> info;
+    array_int16 audioFormat, channels;
+    array_int32 sampleRate, byteRate;
+    array_int16 throwawayInt16, bitsPerSample;
+    std::array<char, 4> prefix;
+    array_int32 size;
+    auto data = std::make_shared<OpenALSoundBuffer>();
+    std::ifstream file(filename, std::ios_base::binary);
+
+    if (!file.good()) return nullptr;
+    file.read(header.data(), 4);
+    if (header != RIFF) return nullptr;
+    read32(file, throwawayInt32);
+    file.read(format.data(), 4);
+    if (format != WAVE) return nullptr;
+    file.read(info.data(), 4);
+    if (info != FMT_) return nullptr;
+    read32(file, throwawayInt32);
+    read16(file, audioFormat);
+    read16(file, channels);
+    read32(file, sampleRate);
+    read32(file, byteRate);
+    read16(file, throwawayInt16);
+    read16(file, bitsPerSample);
+
+    file.read(prefix.data(), 4);
+    if (prefix == LIST) {
+        read32(file, throwawayInt32);
+        file.seekg(throwawayInt32.i, std::ios_base::cur);
+        file.read(prefix.data(), 4);
+    }
+    if (prefix != DATA) return nullptr;
+    read32(file, size);
+    data->buffer.reserve(size.i);
+    data->buffer.insert(data->buffer.begin(), std::istream_iterator<char>(file), std::istream_iterator<char>());
+
+    alGetError();
+    alGenBuffers(1, &data->id);
+    ALenum error = alGetError();
+    if (error != AL_NO_ERROR) return nullptr;
+
+    alBufferData(data->id, alUtilFormatFromWav(channels.i, bitsPerSample.i), data->buffer.data(), size.i, sampleRate.i);
+    error = alGetError();
+    if (error != AL_NO_ERROR) return nullptr;
+
+    data->format = audioFormat.i;
+    data->frequency = sampleRate.i;
+    return data;
+}
+
+bool OpenALSoundEngine::load(const std::string& filename)
+{
+    if (ygo::Utils::GetFileExtension(filename) == "wav") {
+        auto data = loadWav(filename);
+        if (!data) return false;
+        buffers.insert_or_assign(filename, data);
+        return true;
+    }
+    return false;
+}
+
+int OpenALSoundEngine::play(const std::string& filename, bool loop)
+{
+    maintain();
+    if (buffers.find(filename) == buffers.end()) {
+        if (!load(filename)) return -1;
+    }
+    ALuint buffer = buffers.at(filename)->id;
+
+    ALuint source;
+    alGetError();
+    alGenSources(1, &source);
+    ALenum error = alGetError();
+    if (error != AL_NO_ERROR) return -1;
+    
+    alSourcei(source, AL_BUFFER, buffer);
+    alSourcei(source, AL_LOOPING, loop ? AL_TRUE : AL_FALSE);
+    alSourcef(source, AL_GAIN, volume);
+    alSourcePlay(source);
+    error = alGetError();
+    if (error != AL_NO_ERROR) {
+        alDeleteSources(1, &source);
+        return -1;
+    }
+    playing.insert(source);
+    return source;
+}
+
+bool OpenALSoundEngine::exists(int sound)
+{
+    maintain();
+    return playing.find(sound) != playing.end();
+}
+
+void OpenALSoundEngine::stop(int sound)
+{
+    maintain();
+    const auto iter = playing.find(sound);
+    if (playing.find(sound) != playing.end()) {
+        alSourceStop(sound);
+        alDeleteSources(1, &*iter);
+        playing.erase(iter);
+    }
+}
+
+void OpenALSoundEngine::stopAll()
+{
+    for (const auto& iter : playing) {
+        alSourceStop(iter);
+        alDeleteSources(1, &iter);
+    }
+    playing.clear();
+}
+
+void OpenALSoundEngine::setVolume(float gain)
+{
+    volume = gain;
+    for (const auto& iter : playing) {
+        alSourcef(iter, AL_GAIN, volume);
+    }
+}
+
+void OpenALSoundEngine::maintain() {
+    std::unordered_set<ALuint> toDelete;
+    for (const auto& iter : playing) {
+        ALint state;
+        alGetSourcei(iter, AL_SOURCE_STATE, &state);
+        if (state != AL_PLAYING) {
+            toDelete.insert(iter);
+        }
+    }
+    for (const auto& iter : toDelete) {
+        alSourceStop(iter);
+        alDeleteSources(1, &iter);
+        playing.erase(iter);
+    }
+}
+
+} // namespace YGOpen

--- a/gframe/sound_openal.h
+++ b/gframe/sound_openal.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 #include <AL/al.h>
 #include <AL/alc.h>
 

--- a/gframe/sound_openal.h
+++ b/gframe/sound_openal.h
@@ -24,10 +24,18 @@ struct OpenALSoundBuffer
     std::vector<char> buffer;
 };
 
-class OpenALSoundEngine {
+class OpenALSingleton {
 public:
-    OpenALSoundEngine();
-    ~OpenALSoundEngine();
+    OpenALSingleton();
+    ~OpenALSingleton();
+    std::unique_ptr<ALCdevice, void (*)(ALCdevice* ptr)> device;
+    std::unique_ptr<ALCcontext, void(*)(ALCcontext* ptr)> context;
+};
+
+class OpenALSoundLayer {
+public:
+    OpenALSoundLayer(const std::unique_ptr<OpenALSingleton>& openal);
+    ~OpenALSoundLayer();
     bool load(const std::string& filename);
     int play(const std::string& filename, bool loop);
     bool exists(int sound);
@@ -36,8 +44,7 @@ public:
     void setVolume(float gain);
 private:
     void maintain();
-    std::unique_ptr<ALCdevice, void (*)(ALCdevice* ptr)> device;
-    std::unique_ptr<ALCcontext, void(*)(ALCcontext* ptr)> context;
+    const std::unique_ptr<OpenALSingleton>& openal;
     std::unordered_map<std::string, std::shared_ptr<OpenALSoundBuffer>> buffers;
     std::unordered_set<ALuint> playing;
     float volume = 1.0f;

--- a/gframe/sound_openal.h
+++ b/gframe/sound_openal.h
@@ -1,0 +1,47 @@
+#ifndef YGOPEN_SOUND_OPENAL_H
+#define YGOPEN_SOUND_OPENAL_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <AL/al.h>
+#include <AL/alc.h>
+
+namespace YGOpen {
+
+/* Modified from minetest: src/client/sound.h, src/client/sound_openal.cpp
+ * https://github.com/minetest/minetest
+ * Licensed under GNU LGPLv2.1
+ */
+
+struct OpenALSoundBuffer
+{
+    ALenum format;
+    ALsizei frequency;
+    ALuint id;
+    std::vector<char> buffer;
+};
+
+class OpenALSoundEngine {
+public:
+    OpenALSoundEngine();
+    ~OpenALSoundEngine();
+    bool load(const std::string& filename);
+    int play(const std::string& filename, bool loop);
+    bool exists(int sound);
+    void stop(int sound);
+    void stopAll();
+    void setVolume(float gain);
+private:
+    void maintain();
+    std::unique_ptr<ALCdevice, void (*)(ALCdevice* ptr)> device;
+    std::unique_ptr<ALCcontext, void(*)(ALCcontext* ptr)> context;
+    std::unordered_map<std::string, std::shared_ptr<OpenALSoundBuffer>> buffers;
+    std::unordered_set<ALuint> playing;
+    float volume = 1.0f;
+};
+
+}
+
+#endif //YGOPEN_SOUND_OPENAL_H

--- a/premake5.lua
+++ b/premake5.lua
@@ -3,6 +3,10 @@ newoption {
 	description = "Disable DirectX options in irrlicht if the DirectX SDK isn't installed"
 }
 newoption {
+	trigger = "no-irrklang",
+	description = "Disable irrKlang and use OpenAL Soft"
+}
+newoption {
 	trigger = "pics",
 	value = "url_template",
 	description = "Default URL for card images"

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -6,14 +6,14 @@ PICS_URL=${PICS_URL:-""}
 FIELDS_URL=${FIELDS_URL:-""}
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    ./premake5 vs2017 --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\"
+    ./premake5 vs2017 --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\" --no-irrklang
     "$MSBUILD_PATH/msbuild.exe" -m -p:Configuration=$BUILD_CONFIG ./build/ygo.sln -t:ygoprodll
 fi
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    ./premake5 gmake2 --vcpkg-root=$VCPKG_ROOT --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\"
+    ./premake5 gmake2 --vcpkg-root=$VCPKG_ROOT --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\" --no-irrklang
     make -Cbuild -j2 config=$BUILD_CONFIG ygoprodll
 fi
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    ./premake5 gmake2 --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\"
+    ./premake5 gmake2 --pics=\"$PICS_URL\" --fields=\"$FIELDS_URL\" --no-irrklang
     make -Cbuild -j2 config=$BUILD_CONFIG ygoprodll
 fi


### PR DESCRIPTION
Support for at least the same formats as irrKlang. Requires `openal-soft`, `libmpg123`, `libsndfile`, `libvorbis`, `libogg`, and `libFLAC`.

Closes #52 