### PR TITLE
[macOS] Add "New Window" and "Quit" to system menu

### DIFF
--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #ifdef __APPLE__
 #import <CoreFoundation/CoreFoundation.h>
+#include "osx_menu.h"
 #endif
 
 int enable_log = 0;
@@ -64,6 +65,9 @@ int main(int argc, char* argv[]) {
 	ygo::mainGame = &_game;
 	if(!ygo::mainGame->Initialize())
 		return EXIT_FAILURE;
+#ifdef __APPLE__
+	EDOPRO_SetupMenuBar();
+#endif
 	bool keep_on_return = false;
 	for(int i = 1; i < argc; ++i) {
 		path_string parameter(argv[i]);

--- a/gframe/osx_menu.h
+++ b/gframe/osx_menu.h
@@ -5,9 +5,7 @@
 extern "C" {
 #endif
 
-#ifdef __APPLE__
 void EDOPRO_SetupMenuBar();
-#endif
 
 #ifdef __cplusplus
 }

--- a/gframe/osx_menu.h
+++ b/gframe/osx_menu.h
@@ -1,0 +1,16 @@
+#ifndef EDOPRO_OSX_MENU_H
+#define EDOPRO_OSX_MENU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __APPLE__
+void EDOPRO_SetupMenuBar();
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EDOPRO_OSX_MENU_H */

--- a/gframe/osx_menu.m
+++ b/gframe/osx_menu.m
@@ -1,0 +1,23 @@
+#include "osx_menu.h"
+#import <AppKit/AppKit.h>
+
+void EDOPRO_SetupMenuBar() {
+    @autoreleasepool {
+        // Apparently in a newer version of Irrlicht's CIrrDeviceOSX.mm
+
+        NSString* bundleName = @""; // Cannot actually set the main menu title at runtime
+        NSMenu* systemMenuBar = [[[NSMenu alloc] initWithTitle:@"MainMenu"] autorelease];
+        NSMenu* appMainMenu = [[[NSMenu alloc] initWithTitle:bundleName] autorelease];
+
+        NSMenuItem* appMainMenuOpener = [systemMenuBar addItemWithTitle:bundleName action:nil keyEquivalent:@""];
+        [systemMenuBar setSubmenu:appMainMenu forItem:appMainMenuOpener];
+
+        NSMenuItem* newWindowItem = [appMainMenu addItemWithTitle:@"New Window" action:nil keyEquivalent:@"n"];
+        [newWindowItem setKeyEquivalentModifierMask:NSCommandKeyMask];
+
+        NSMenuItem* quitItem = [appMainMenu addItemWithTitle:@"Quit" action:@selector(terminate:) keyEquivalent:@"q"];
+        [quitItem setKeyEquivalentModifierMask:NSCommandKeyMask];
+
+        [NSApp setMainMenu:systemMenuBar];
+    }
+}

--- a/gframe/osx_menu.m
+++ b/gframe/osx_menu.m
@@ -1,6 +1,18 @@
 #include "osx_menu.h"
 #import <AppKit/AppKit.h>
 
+@interface NewAppInstanceHandler : NSObject
+-(void)spawn;
+@end
+
+@implementation NewAppInstanceHandler
+-(void)spawn {
+    const char* abspath = [[[NSBundle mainBundle] bundlePath] UTF8String];
+    char command[256] = "open -n ";
+    system(strcat(command, abspath));
+}
+@end
+
 void EDOPRO_SetupMenuBar() {
     @autoreleasepool {
         // Apparently in a newer version of Irrlicht's CIrrDeviceOSX.mm
@@ -12,7 +24,9 @@ void EDOPRO_SetupMenuBar() {
         NSMenuItem* appMainMenuOpener = [systemMenuBar addItemWithTitle:bundleName action:nil keyEquivalent:@""];
         [systemMenuBar setSubmenu:appMainMenu forItem:appMainMenuOpener];
 
-        NSMenuItem* newWindowItem = [appMainMenu addItemWithTitle:@"New Window" action:nil keyEquivalent:@"n"];
+        NSMenuItem* newWindowItem = [appMainMenu addItemWithTitle:@"New Window" action:@selector(spawn) keyEquivalent:@"n"];
+        NewAppInstanceHandler* handler = [[NewAppInstanceHandler alloc] init];
+        [newWindowItem setTarget:handler];
         [newWindowItem setKeyEquivalentModifierMask:NSCommandKeyMask];
 
         NSMenuItem* quitItem = [appMainMenu addItemWithTitle:@"Quit" action:@selector(terminate:) keyEquivalent:@"q"];

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -49,6 +49,7 @@ local ygopro_config=function(static_core)
 		defines "LUA_USE_MACOSX"
 		buildoptions { "-fms-extensions" }
 		includedirs { "/usr/local/include/freetype2", "/usr/local/include/irrlicht" }
+		files "osx_menu.m"
 		linkoptions { "-Wl,-rpath ./" }
 		libdirs "../irrKlang/bin/macosx-gcc/"
 		links { "fmt", "curl", "Cocoa.framework", "IOKit.framework", "OpenGL.framework" }


### PR DESCRIPTION
- Command+N maps to "New Window", spawning a new, independent instance of the game via `open -n`
- Command+Q maps to "Quit" as expected of other macOS applications

Closes #28 

Please look over this briefly if there appears to be anything incredibly wrong with the code or how it is called. Otherwise, I've confirmed that this works on my machine, and we can have our other macOS testers confirm once this is merged to `master`.