### PR TITLE
[Fix] Add AI's name and connected with Bot Preferences window

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1146,11 +1146,11 @@ void Game::RefreshAiDecks() {
 }
 #ifdef _WIN32
 path_string Game::GetAiParameter(BotInfo bot, int port) {
-	return fmt::format(TEXT("./Windbot/Windbot.exe Deck=\"a{}\" Port={} Version={}"),bot.deck.c_str(),port, PRO_VERSION);
+	return fmt::format(TEXT("./Windbot/Windbot.exe Deck=\"a{}\" Port={} Version={} name=\"[AI] {}\""),bot.deck.c_str(), port, PRO_VERSION, bot.name.c_str());
 }
 #else
 Game::BotParams Game::GetAiParameter(BotInfo bot, int port) {
-	return { fmt::format("Deck=\"{}\"", BufferIO::EncodeUTF8s(bot.deck).c_str()), fmt::format("Port={}", port), fmt::format("Version={}", PRO_VERSION) };
+	return { fmt::format("Deck={}", BufferIO::EncodeUTF8s(bot.deck).c_str()), fmt::format("Port={}", port), fmt::format("Version={}", PRO_VERSION), fmt::format("name=[AI] {}", BufferIO::EncodeUTF8s(bot.name).c_str())};
 }
 
 #endif

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -142,6 +142,7 @@ public:
 		std::string arg1;
 		std::string arg2;
 		std::string arg3;
+		std::string arg4;
 	};
 	BotParams GetAiParameter(BotInfo bot, int port);
 

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -80,11 +80,11 @@ bool LaunchWindbot(const BotInfo& bot, int port) {
 	int pid = fork();
 	if(pid== 0) {
 		chdir("WindBot");
-		printf("%s %s %s\n", param.arg1.c_str(), param.arg2.c_str(), param.arg3.c_str());
+		printf("%s %s %s %s\n", param.arg1.c_str(), param.arg2.c_str(), param.arg3.c_str(), param.arg4.c_str());
 #ifdef __APPLE__
-		execlp("mono", "WindBot.exe", "WindBot.exe", param.arg1.c_str(), param.arg2.c_str(), param.arg3.c_str(), NULL);
+		execlp("mono", "WindBot.exe", "WindBot.exe", param.arg1.c_str(), param.arg2.c_str(), param.arg3.c_str(), param.arg4.c_str(), NULL);
 #else
-		execl("./WindBot.exe", "WindBot", param.arg1.c_str(), param.arg2.c_str(), param.arg3.c_str(), NULL);
+		execl("./WindBot.exe", "WindBot", param.arg1.c_str(), param.arg2.c_str(), param.arg3.c_str(), param.arg4.c_str(), NULL);
 #endif
 		perror("Failed to start WindBot");
 		exit(EXIT_FAILURE);
@@ -396,7 +396,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_BOT_START: {
 				int port = std::stoi(mainGame->gameConf.serverport);
-				int index = 2;
+				int index = mainGame->gBot.deckBox->getSelected();
 				if(!NetServer::StartServer(port))
 					break;
 				if(!DuelClient::StartClient(0x7f000001, port)) {
@@ -410,7 +410,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_BOT_ADD: {
 				int port = std::stoi(mainGame->gameConf.serverport);
-				volatile int index = 2;
+				volatile int index = mainGame->gBot.deckBox->getSelected();
 				LaunchWindbot(mainGame->bots[index], port);
 				break;
 			}


### PR DESCRIPTION
* When spawned, the AI was always named "Windbot" => Now it's "[AI] + deck name (from the json)
* On Linux, when spawned, Windbot couldn't find the specified deck and loaded a random one => Now it loads the specified deck
* Connected the Bot Preferences Widget => Can choose which deck to use against instead of the Dragunity one (hardcoded index 2)